### PR TITLE
Added shunting yard, split query, and the various evalAND methods

### DIFF
--- a/Node.py
+++ b/Node.py
@@ -9,6 +9,7 @@ class Node(object):
         self.termWeight = termWeight
         self.vectorDocLength = vectorDocLength
         self.positionalList = positionalList
+        self.skipPointer = 0  # target index = skipPointer + currentIndex
 
 
     def getTermFrequency(self):
@@ -37,3 +38,15 @@ class Node(object):
 
     def getDocID(self):
         return self.docID
+
+    def addSkipPointer(self, value):
+        """
+        Adds a skip pointer to the Node
+        """
+        self.skipPointer = value
+
+    def hasSkip(self):
+        """
+        Checks if the Node contains a skip pointer.
+        """
+        return self.skipPointer != 0

--- a/Operand.py
+++ b/Operand.py
@@ -1,0 +1,30 @@
+class Operand(object):
+    """
+    Operand is a class that encapsulates the attributes and behaviour of an operand in logical expressions.
+    It serves to simplify the evaluation of logical expressions.
+    """
+
+    def __init__(self, term=None, result=None):
+        self.term = term
+        self.result = result
+
+    def __repr__(self):
+        return str(self.term)
+
+    def isTerm(self):
+        """
+        Checks if Operand is a term and not a result
+        """
+        return not isinstance(self.term, type(None))
+
+    def isResult(self):
+        """
+        Checks if Operand is a result and not a term
+        """
+        return not isinstance(self.result, type(None))
+
+    def getResult(self):
+        return self.result
+
+    def getTerm(self):
+        return self.term


### PR DESCRIPTION
Modifications were made to shunting yard and split query, evalAND methods were mostly kept the same (compared to hw2 and hw3).
- Shunting yard only recognises the "AND" operator (the rest not needed).
- Split query will split the string into tokens as usual, but will keep the phrases together. E.g.:
"example AND "phrase query" AND example" ->
["example", "AND", "phrase query", "AND", "example"]