### PR TITLE
Fix positional list implementation

### DIFF
--- a/SPIMI.py
+++ b/SPIMI.py
@@ -56,13 +56,14 @@ def createPositionalDict(tokenStream):
 
     for trio in tokenStream:
         term = trio[0]
+
         if term in positionalDict:
             positionalDict[term].append(index)
-            index += 1
 
         else: # term not in positionalDict yet
             positionalDict[term] = [index]
-            index += 1
+
+        index += 1
 
     return positionalDict
 
@@ -133,9 +134,12 @@ def mergePostingsDict(dict1, dict2):
     result = {}
 
     for docID in unionOfDocIDs:
+        posList = getPositionalList(dict1, docID)
+        posList.extend(getPositionalList(dict2, docID))
         result[docID] = [getTermFrequency(dict1, docID) + getTermFrequency(dict2, docID), 
-            max(getTermWeight(dict1, docID), getTermWeight(dict2, docID)), max(getVectorDocLength(dict1, docID), getVectorDocLength(dict2, docID),
-            getPositionalList(dict1, docID).append(getPositionalList, docID))]
+            max(getTermWeight(dict1, docID), getTermWeight(dict2, docID)), 
+            max(getVectorDocLength(dict1, docID), getVectorDocLength(dict2, docID)),
+            posList]
             # max() is used because of the way we process files; we process documents fully, and 1024 at a time. Thus, no 2 dictionary file will contain the same
             # docIDs. max() is used because we don't know which of the 2 dictionary contains a particular docID.
             # This is true for positional lists as well.

--- a/SPIMI.py
+++ b/SPIMI.py
@@ -58,7 +58,10 @@ def createPositionalDict(tokenStream):
         term = trio[0]
 
         if term in positionalDict:
-            positionalDict[term].append(index)
+            lengthOfPositionalIndex = len(positionalDict[term])
+            prevIndex = positionalDict[term][lengthOfPositionalIndex - 1]
+            indexDiff = index - prevIndex
+            positionalDict[term].append(indexDiff)
 
         else: # term not in positionalDict yet
             positionalDict[term] = [index]

--- a/SPIMI.py
+++ b/SPIMI.py
@@ -9,6 +9,7 @@ def SPIMIInvert(tokenStreamBatch, outputFile, dictFile):
     This function is akin to the one we've seen the in textbook. Each call to
     SPIMIInvert writes a block to disk.
     """
+    # this processes the terms in each document individually.
     # tokenStreamBatch: [(docID, [(term1, weight, docVectorLength), (term2, weight, docVectorLength), ...]), (docID2, [(term1, weight, docVectorLength), (term2, weight, docVectorLength), ...]]
     tempDict = {} # {term : {docID : [termFreq, weight, vectorLength, positionalList], docID2 : [termFreq, weight, vectorLength2, positionalList], ...}, term2 : ...}
     termDict = TermDictionary(dictFile)
@@ -47,6 +48,7 @@ def SPIMIInvert(tokenStreamBatch, outputFile, dictFile):
 
 
 def createPositionalDict(tokenStream):
+    # tokenStream is a list of terms with their relevant data
     # facilitates phrasal queries.
     # creates a dictionary of {term: [index1, index2, ...], term2: [index1, index2, ...], ...} for content from a particular document.
     index = 0

--- a/index.py
+++ b/index.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import csv
-import regex
 import string
 import shutil
 import nltk
@@ -30,7 +29,7 @@ def build_index(in_dir, out_dict, out_postings):
 
     tempFile = 'temp.txt'
     workingDirectory = "workingDirectory/"
-    limit = 10000 # max number of docs to be processed at any 1 time.
+    limit = 10000 # max number of docs to be processed at any 1 time. production = 10000, testing = 20
     result = TermDictionary(out_dict)
 
     # set up temp directory for SPIMI process
@@ -55,10 +54,11 @@ def build_index(in_dir, out_dict, out_postings):
         except OverflowError:
             maxInt = int(maxInt / 10)
 
+    # totalCount = 0 # testing code
     with open(input_directory, newline='', encoding='UTF-8') as f:
         reader = csv.reader(f)
 
-        for row, col in tqdm(enumerate(reader)):
+        for row, col in tqdm(enumerate(reader)): # no. of iterations = no. of documents to process
             if row == 0:
                 continue # skips row 0 (to avoid procesing field names)
 
@@ -68,6 +68,10 @@ def build_index(in_dir, out_dict, out_postings):
             docLengths[docID] = len(tokenStream)
             tokenStreamBatch.append((int(docID), tokenStream))
             count += 1
+            # totalCount += 1 # testing code
+
+            # if totalCount == 55: # testing code
+            #     break
 
             if count == limit: # no. of docs == limit
                 outputPostingsFile = workingDirectory + 'tempPostingFile' + str(fileID) + '_stage' + str(stageOfMerge) + '.txt'
@@ -109,12 +113,12 @@ def generateProcessedTokenStream(content):
 
     rawTokens = nltk.tokenize.word_tokenize(content) # an array of individual terms (consisting of words, standalone punctuations and numbers)
     processedTokens_1 = list(filter(isNotPunctuation, rawTokens)) # no standalone punctuations
-    # print(tokenNoPunctuations)
     tokensNoStopWords = [token for token in processedTokens_1 if token.lower() not in stopwords.words('english')] # remove all occurrences of stopwords
-    # print(tokensNoStopWords)
+    stemmedTerms = []
 
     for word in tokensNoStopWords:
         stemmedWord = stemmer.stem(word.lower())
+        stemmedTerms.append(stemmedWord)
 
         if stemmedWord in countOfTerms:
             countOfTerms[stemmedWord] += 1
@@ -122,10 +126,12 @@ def generateProcessedTokenStream(content):
         else:
             countOfTerms[stemmedWord] = 1
 
-    weightOfTerms = {term : 1 + math.log10(value) for term, value in countOfTerms.items()} # no idf
+    weightOfTerms = {term : 1 + math.log10(value) for term, value in countOfTerms.items()} # no idf, deals with unique terms only
     lengthOfDocVector = math.sqrt(sum([count**2 for count in weightOfTerms.values()]))
 
-    output = [(term, weight, lengthOfDocVector) for term, weight in weightOfTerms.items()] # all terms in a particular document, and its associated term weight, and length of vector
+    output = [(term, weightOfTerms[term], lengthOfDocVector) for term in stemmedTerms]
+    
+    # output = [(term, weight, lengthOfDocVector) for term, weight in weightOfTerms.items()] # all terms in a particular document, and its associated term weight, and length of vector
 
     return output  # returns a list of processed terms in the form of [(term1, weight, docVectorLength), (term2, weight, docVectorLength), ...]
 

--- a/index.py
+++ b/index.py
@@ -9,6 +9,7 @@ import getopt
 import os
 import pickle
 import math
+import regex
 from tqdm import tqdm
 
 
@@ -29,7 +30,7 @@ def build_index(in_dir, out_dict, out_postings):
 
     tempFile = 'temp.txt'
     workingDirectory = "workingDirectory/"
-    limit = 10000 # max number of docs to be processed at any 1 time. production = 10000, testing = 20
+    limit = 8096 # max number of docs to be processed at any 1 time. production = 10000, testing = 20
     result = TermDictionary(out_dict)
 
     # set up temp directory for SPIMI process
@@ -112,8 +113,8 @@ def generateProcessedTokenStream(content):
     countOfTerms = {}
 
     rawTokens = nltk.tokenize.word_tokenize(content) # an array of individual terms (consisting of words, standalone punctuations and numbers)
-    processedTokens_1 = list(filter(isNotPunctuation, rawTokens)) # no standalone punctuations
-    tokensNoStopWords = [token for token in processedTokens_1 if token.lower() not in stopwords.words('english')] # remove all occurrences of stopwords
+    tokensNoStopWords = [removeNonAlphanumeric(term) for term in list(filter(isNotPunctuation, rawTokens))] # no standalone punctuations, this is tokensNoStopWords in testing, and processedTokens_1 in production
+    # tokensNoStopWords = [token for token in processedTokens_1 if token.lower() not in stopwords.words('english')] # remove all occurrences of stopwords
     stemmedTerms = []
 
     for word in tokensNoStopWords:
@@ -129,9 +130,7 @@ def generateProcessedTokenStream(content):
     weightOfTerms = {term : 1 + math.log10(value) for term, value in countOfTerms.items()} # no idf, deals with unique terms only
     lengthOfDocVector = math.sqrt(sum([count**2 for count in weightOfTerms.values()]))
 
-    output = [(term, weightOfTerms[term], lengthOfDocVector) for term in stemmedTerms]
-    
-    # output = [(term, weight, lengthOfDocVector) for term, weight in weightOfTerms.items()] # all terms in a particular document, and its associated term weight, and length of vector
+    output = [(term, weightOfTerms[term], lengthOfDocVector) for term in stemmedTerms] # all terms in a particular document, and its associated term weight, and length of vector
 
     return output  # returns a list of processed terms in the form of [(term1, weight, docVectorLength), (term2, weight, docVectorLength), ...]
 
@@ -141,6 +140,20 @@ def isNotPunctuation(token):
         return False
     
     return True
+
+
+def isNumeric(string):
+    if regex.match(r'[0-9]+[^0-9][0-9]+', string):
+        return True
+    else:
+        return False
+
+
+def removeNonAlphanumeric(string):
+    if not isNumeric(string):
+        return regex.sub(r'[^a-zA-Z0-9\_\-\p{Sc}]', ' ', string)
+    else:
+        return string
 
 
 def convertToPostingNodes(out_postings, file, termDictionary):

--- a/phrasal.py
+++ b/phrasal.py
@@ -133,10 +133,17 @@ def isPhraseInTwoPositionalList(positionalList1, positionalList2):
     """
     marker1 = 0
     marker2 = 0
+    position_1 = 0 # with postings compression
+    position_2 = 0 # with postings compression
 
     while (marker1 < len(positionalList1)) and (marker2 < len(positionalList2)):
-        position_1 = positionalList1[marker1]
-        position_2 = positionalList2[marker2]
+        # with postings compression
+        position_1 += positionalList1[marker1]
+        position_2 += positionalList2[marker2]
+
+        # without postings compression
+        # position_1 = positionalList1[marker1]
+        # position_2 = positionalList2[marker2]
 
         if position_1 + 1 == position_2:
             return True
@@ -160,11 +167,20 @@ def isPhraseInThreePositionalList(positionalList1, positionalList2, positionalLi
     marker1 = 0
     marker2 = 0
     marker3 = 0
+    position_1 = 0 # with postings compression
+    position_2 = 0 # with postings compression
+    position_3 = 0 # with postings compression
 
     while (marker1 < len(positionalList1)) and (marker2 < len(positionalList2)) and (marker3 < len(positionalList3)):
-        position_1 = positionalList1[marker1]
-        position_2 = positionalList2[marker2]
-        position_3 = positionalList3[marker3]
+        # with postings compression
+        position_1 += positionalList1[marker1]
+        position_2 += positionalList2[marker2]
+        position_3 += positionalList3[marker3]
+
+        # without postings compression
+        # position_1 = positionalList1[marker1]
+        # position_2 = positionalList2[marker2]
+        # position_3 = positionalList3[marker3]
 
         if (position_1 + 1 == position_2) and (position_2 + 1 == position_3):
             return True


### PR DESCRIPTION
Previously, all occurrences of a term were collapsed into a single occurrence. Hence, positional lists were of length 1